### PR TITLE
adding laposte.fr in common providers

### DIFF
--- a/data/common_providers.txt
+++ b/data/common_providers.txt
@@ -18,6 +18,7 @@ hotmail.com
 hotmail.fr
 icloud.com
 laposte.net
+laposte.fr
 live.co.uk
 live.com
 live.fr

--- a/data/common_providers.txt
+++ b/data/common_providers.txt
@@ -33,6 +33,7 @@ outlook.fr
 rocketmail.com
 sbcglobal.net
 sfr.fr
+sfr.com
 sky.com
 talktalk.net
 verizon.net

--- a/spec/cases/typos_laposte_spec.rb
+++ b/spec/cases/typos_laposte_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Case: La Poste typos" do
   %w[
     john.doe@lapost.net
     john.doe@laposte.com
-    john.doe@laposte.fr
     john.doe@laposte.ne
     john.doe@laposte.ner
     john.doe@lapostr.net

--- a/spec/cases/typos_other_spec.rb
+++ b/spec/cases/typos_other_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "Case: Other typos" do
   %w[
     john.doe@sf.fr
     john.doe@sfe.fr
-    john.doe@sfr.com
     john.doe@sfr.fe
     john.doe@sft.fr
   ].each do |kase|


### PR DESCRIPTION
Employees of La Poste and SFR have email address `@laposte.fr` and `@sfr.com`. To not suggest a `:hint` we suggest adding these providers to the list of common_providers.